### PR TITLE
Fix error in data.py caused by using numpy instead of lab

### DIFF
--- a/src/scnn/private/interface/data.py
+++ b/src/scnn/private/interface/data.py
@@ -81,8 +81,8 @@ def process_data(
 
     # add extra target dimension if necessary
     if len(y_train.shape) == 1:
-        y_train = np.expand_dims(y_train, axis=1)
-        y_test = np.expand_dims(y_test, axis=1)
+        y_train = lab.expand_dims(y_train, axis=1)
+        y_test = lab.expand_dims(y_test, axis=1)
 
     train_set, test_set, col_norms = (X_train, y_train), (X_test, y_test), None
 


### PR DESCRIPTION
Hi,

The `process_data` function was still using `numpy` for `expand_dim`s, which caused an error since `numpy` is no longer imported. I updated it to use `lab.expand_dims` instead to resolve the error.